### PR TITLE
[NO-ISSUE] Add marker to cells

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,18 +1,25 @@
 console.log('Hello world🌊');
 
 const gameBoard = (() => {
+  const emptyCell = ' ';
+
   const grid = [
-    'A', 'T', '',
-    '',  '',  '',
-    '',  '',  '',
+    emptyCell, emptyCell, emptyCell,
+    emptyCell, emptyCell, emptyCell,
+    emptyCell, emptyCell, emptyCell,
   ];
 
-  const addMarkerAt = function(marker, cellIndex) {
+  const placeMarkerAt = function(marker, cellIndex) {
     grid[cellIndex] = marker;
   };
 
+  const isCellTaken = function(cellIndex) {
+    return grid[cellIndex] !== emptyCell;
+  }
+
   return {
-    placeMarkerAt: addMarkerAt,
+    placeMarkerAt,
+    isCellTaken,
     grid
   };
 })();
@@ -51,10 +58,11 @@ const gameplayController = (function(board, players) {
   };
 
   const playTurn = function(cellIndex) {
+    // Don't allow playing a turn on a cell that's already been played on.
+    if (board.isCellTaken(cellIndex)) return;
+
     const marker = activePlayer.marker;
-
     board.placeMarkerAt(marker, cellIndex);
-
     switchTurns();
   };
 
@@ -70,8 +78,8 @@ const gameplayController = (function(board, players) {
   Takes in a one-dimensional list of markers on each gameboard grid cell.
 
   e.g.
-  ['X', 'O', '', '', '', '', '', 'X', 'O']
-    0    1   2   3   4   5   6    7    8
+  ['X', 'O', ' ', ' ', ' ', ' ', ' ', 'X', 'O']
+    0    1    2    3    4    5    6    7    8
 
   is equivalent to...
 

--- a/js/index.js
+++ b/js/index.js
@@ -99,9 +99,17 @@ const displayController = function(gameBoard) {
     })
   };
 
+  const markCellAsPlayed = function(cellIndex) {
+    const rootContainer = document.querySelector('#game-board');
+    const cells = [...rootContainer.children];
+    
+    cells[cellIndex].setAttribute('disabled', true);
+  };
+
   const playTurn = function(cellIndex) {
     gameplayController.playTurn(cellIndex);
     render();
+    markCellAsPlayed(cellIndex);
   }
 
   // IIFE to generate event listeners only once at time of initial load.

--- a/js/index.js
+++ b/js/index.js
@@ -54,13 +54,14 @@ const gameplayController = (function(board, players) {
     const marker = activePlayer.marker;
 
     board.placeMarkerAt(marker, cellIndex);
+
+    switchTurns();
   };
 
   return {
     board,
     getActivePlayer,
     getNextPlayer,
-    switchTurns,
     playTurn,
   };
 })(gameBoard, playerList);
@@ -90,12 +91,27 @@ const displayController = function(gameBoard) {
     })
   };
 
+  const playTurn = function(cellIndex) {
+    gameplayController.playTurn(cellIndex);
+    render();
+  }
+
+  // IIFE to generate event listeners only once at time of initial load.
+  const tieCellsToClickActions = (function() {
+    const rootContainer = document.querySelector('#game-board');
+    const cells = [...rootContainer.children];
+
+    cells.forEach((cell, index) => {
+      cell.addEventListener('click', playTurn.bind(this, index));
+    });
+  })();
+
   return {
     render
   };
 };
 
-const cc = displayController(gameBoard.grid);
+const cc = displayController(gameplayController.board.grid);
 cc.render();
 
 // console.log(gameplayController.board);

--- a/js/index.js
+++ b/js/index.js
@@ -7,7 +7,12 @@ const gameBoard = (() => {
     '',  '',  '',
   ];
 
+  const addMarkerAt = function(marker, cellIndex) {
+    grid[cellIndex] = marker;
+  };
+
   return {
+    placeMarkerAt: addMarkerAt,
     grid
   };
 })();
@@ -43,13 +48,20 @@ const gameplayController = (function(board, players) {
 
   const switchTurns = function() {
     activePlayer = getNextPlayer();
-  }
+  };
+
+  const playTurn = function(cellIndex) {
+    const marker = activePlayer.marker;
+
+    board.placeMarkerAt(marker, cellIndex);
+  };
 
   return {
     board,
     getActivePlayer,
     getNextPlayer,
     switchTurns,
+    playTurn,
   };
 })(gameBoard, playerList);
 
@@ -83,7 +95,8 @@ const displayController = function(gameBoard) {
   };
 };
 
-const cc = displayController(gameBoard.grid).render();
+const cc = displayController(gameBoard.grid);
+cc.render();
 
 // console.log(gameplayController.board);
 // console.log(gameplayController.getActivePlayer());


### PR DESCRIPTION
## Details

This PR adds the ability and feature for players to play their turn with the UI, rendering and setting event listeners on cells, and preventing players from placing their marker on an already occupied cell.